### PR TITLE
Set the transient duration for the secret to match its lease duration

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -53,7 +53,7 @@ function get_secret( string $secret ) : ?array {
 			return null;
 		}
 
-		set_transient( $transient, $data, 0 );
+		set_transient( $transient, $data, $data['lease_duration'] );
 		schedule_next_secret_update( $secret, $data );
 	}
 
@@ -141,7 +141,7 @@ function update_secret( string $secret ) : void {
 		return;
 	}
 
-	set_transient( get_transient_name( $secret ), $data, 0 );
+	set_transient( get_transient_name( $secret ), $data, $data['lease_duration'] );
 	schedule_next_secret_update( $secret, $data );
 	release_secret_lock( $secret );
 }


### PR DESCRIPTION
When updating a secret, `update_secret()` calls `get_secret_from_vault()`. If an exception is thrown then `update_secret()` releases its concurrency lock and immediately returns.

The result of this is that a stale value for the secret remains in the transient indefinitely because no additional cron event is scheduled to attempt to refresh it asynchronously, and calling `get_secret()` will only ever return the stale value of the transient with no attempt to refresh it synchronously.

By setting the transient's timeout to match that of the secret's lease duration, it means that if a scheduled refresh fails (for example due to an invalid or expired Vault auth token) then the value of the transient will only continue to be stored until its lease expires. At this point, `get_transient()` will return false when called within `get_secret()`, thus triggering a synchronous refresh.

To discuss: The transient timeout might need to be set to slightly less than the lease duration of its secret, to ensure that it gets refreshed before it expires, similarly to the fact the cron event which gets scheduled approximately 0.8 of the way through the lease duration. Maybe the transient expiry could be ( lease duration - 30 seconds ).