### PR TITLE
Set transient duration shorter than its secret's lease duration.

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -53,7 +53,7 @@ function get_secret( string $secret ) : ?array {
 			return null;
 		}
 
-		set_transient( $transient, $data, $data['lease_duration'] );
+		set_transient( $transient, $data, $data['lease_duration'] - 10 );
 		schedule_next_secret_update( $secret, $data );
 	}
 
@@ -141,7 +141,7 @@ function update_secret( string $secret ) : void {
 		return;
 	}
 
-	set_transient( get_transient_name( $secret ), $data, $data['lease_duration'] );
+	set_transient( get_transient_name( $secret ), $data, $data['lease_duration'] - 10 );
 	schedule_next_secret_update( $secret, $data );
 	release_secret_lock( $secret );
 }


### PR DESCRIPTION
If an async refresh fails, it is possible that `get_secret()` could return
`null` between its value expiring and a new secret being refreshed.

In conjunction with the async refresh process, setting the transient
duration's slightly less than the secret's lease duration should remove this
possibility in normal operation.

If a failure occurs after all of this, then there's a bigger problem with the
connection that will need manual intervention to resolve.